### PR TITLE
DC- 2340 Update reCaptcha to version 3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-* [DC-2340] Update reCaptcha version to 3
+* [DC-2340] Update reCaptcha to version 3
 
 ## 1.7.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Formerly
 
+## Unreleased
+
+* [DC-2340] Update reCaptcha version to 3
+
 ## 1.7.0
 
 * [DC-1475] Modify Formerly plugin to add reCaptcha validation

--- a/FormerlyPlugin.php
+++ b/FormerlyPlugin.php
@@ -10,7 +10,7 @@ class FormerlyPlugin extends BasePlugin
 
 	public function getVersion()
 	{
-	    return '1.7.0';
+	    return '1.8.0';
 	}
 
 	public function getDeveloper()

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Formerly 1.7.0
+# Formerly 1.8.0
 
 ## Installing
 

--- a/controllers/Formerly_FormsController.php
+++ b/controllers/Formerly_FormsController.php
@@ -104,10 +104,7 @@ class Formerly_FormsController extends BaseController
     $form->name    = craft()->request->getPost('name');
     $form->handle  = craft()->request->getPost('handle');
     $form->emails  = craft()->request->getPost('emails');
-    $form->reCaptcha  = craft()->request->getPost('reCaptcha');
-    $form->reCaptchaSiteKey  = craft()->request->getPost('reCaptchaSiteKey');
-    $form->reCaptchaSecretKey  = craft()->request->getPost('reCaptchaSecretKey');
-
+  
     $postedQuestions = craft()->request->getPost('questions');
     $sortOrder = 0;
 

--- a/controllers/Formerly_SubmissionsController.php
+++ b/controllers/Formerly_SubmissionsController.php
@@ -124,11 +124,9 @@ class Formerly_SubmissionsController extends BaseController
     $form = $submission->getForm();
 
     $verified = true;
-    if ($form->reCaptcha == 1) {
-      $verified = craft()->formerly_verify->verify($captchaResponse, $form);
-      if (!$verified) {
-        $submission->addError('reCaptcha', 'Failed reCAPTCHA validation.');
-      }
+    $verified = craft()->formerly_verify->verify($captchaResponse, $form);
+    if (!$verified) {
+      $submission->addError('reCaptcha', 'Failed reCAPTCHA validation.');
     }
 
     $submission->setContentFromPost('questions');

--- a/models/Formerly_FormModel.php
+++ b/models/Formerly_FormModel.php
@@ -12,9 +12,6 @@ class Formerly_FormModel extends BaseModel
       'instructions'      => AttributeType::String,
       'handle'            => AttributeType::String,
       'emails'            => AttributeType::Mixed,
-      'reCaptcha'           => AttributeType::Bool,
-      'reCaptchaSiteKey'    => AttributeType::String,
-      'reCaptchaSecretKey'  => AttributeType::String,
     );
   }
 

--- a/records/Formerly_FormRecord.php
+++ b/records/Formerly_FormRecord.php
@@ -14,9 +14,6 @@ class Formerly_FormRecord extends BaseRecord
       'name'          => array(AttributeType::Name, 'required' => true),
       'handle'        => array(AttributeType::Handle, 'required' => true),
       'emails'        => AttributeType::Mixed,
-      'reCaptcha'          => array(AttributeType::Bool, 'label' => 'Use Google reCaptcha', 'default' => false),
-      'reCaptchaSiteKey'   => array(AttributeType::String, 'label' => 'Google reCaptcha API Site Key'),
-      'reCaptchaSecretKey' => array(AttributeType::String, 'label' => 'Google reCaptcha API Secret Key'),
     );
   }
 

--- a/services/Formerly_FormsService.php
+++ b/services/Formerly_FormsService.php
@@ -54,9 +54,6 @@ class Formerly_FormsService extends BaseApplicationComponent
     $formRecord->name    = $form->name;
     $formRecord->handle  = $form->handle;
     $formRecord->emails  = $form->emails;
-    $formRecord->reCaptcha  = $form->reCaptcha;
-    $formRecord->reCaptchaSiteKey  = $form->reCaptchaSiteKey;
-    $formRecord->reCaptchaSecretKey  = $form->reCaptchaSecretKey;
 
     $transaction = craft()->db->getCurrentTransaction() === null ? craft()->db->beginTransaction() : null;
     try

--- a/services/Formerly_VerifyService.php
+++ b/services/Formerly_VerifyService.php
@@ -7,8 +7,10 @@ class Formerly_VerifyService extends BaseApplicationComponent
   {
     $base = "https://www.google.com/recaptcha/api/siteverify";
 
+    $recaptchaSettings = craft()->globals->getSetByHandle('recaptcha');
+
     $params = array(
-      'secret' =>  $form->reCaptchaSecretKey,
+      'secret' => $recaptchaSettings->reCaptchaSecretKey,
       'response' => $captchaResponse
     );
 
@@ -21,7 +23,7 @@ class Formerly_VerifyService extends BaseApplicationComponent
     if($result->getStatusCode() == 200)
     {
       $json = $result->json();
-      if($json['success'])
+      if($json['success']) 
       {
         return true;
       } else {

--- a/templates/forms/_edit.html
+++ b/templates/forms/_edit.html
@@ -193,30 +193,6 @@
       required: true
     }) }}
 
-    {{ forms.checkbox({
-      label: 'Use Google reCaptcha'|t,
-      id: 'reCaptcha',
-      name: 'reCaptcha',
-      checked: form ? form.reCaptcha,
-      errors: form.getErrors('reCaptcha')
-    }) }}
-
-    {{ forms.textField({
-      label: 'Google reCaptcha Site Key'|t,
-      id: 'reCaptchaSiteKey',
-      name: 'reCaptchaSiteKey',
-      value: form.reCaptchaSiteKey,
-      errors: form.getErrors('reCaptchaSiteKey')
-    }) }}
-
-    {{ forms.textField({
-      label: 'Google reCaptcha Secret Key'|t,
-      id: 'reCaptchaSecretKey',
-      name: 'reCaptchaSecretKey',
-      value: form.reCaptchaSecretKey,
-      error: form.getErrors('reaptchaSecretKey')
-    }) }}
-
     <hr>
 
     <h2>Emails</h2>


### PR DESCRIPTION
### Why

To update reCaptcha to version 3.

I removed all reCaptcha related fields from Formerly form settings.
All forms in a site will share the same reCaptcha settings which are defined in Global now.
The global section in the CMS.

### Test it on local

1. Open One SeaLink project
2. Run `git checkout DC-2333-upgrade-to-re-captcha-v3`
3. Update formerly version to 1.8.0-alpha.0 on composer.json file 
   `"sealink/formerly": "1.8.0-alpha.0"`
4. Run `composer update`
5. Run One SeaLink Project 
  `bin/development/launch/php` and `bin/development/launch/webpack`

6. Go to the admin page (/sladmin)
7. Go to the Migration Manager and run the migration file(m190418_111824_migration_add_recaptcha_files_to_global.php)
8. Go to Globals/reCaptcha and input Site Key and Secret Key

   - Test Site Key: **6Lcwpp4UAAAAAGH9SuZMa-lhXi2VjQnsL_9XAsB7**
   - Test Secret Key: **6Lcwpp4UAAAAAJETGsPgNyyCoPqjOZ1F9AIwf4ur**

11. Check forms (/contact)

### Check Results

**Page**
https://onesealink-next-cms.quicktravel.com.au/contact

**CMS**
https://onesealink-next-cms.quicktravel.com.au/sladmin/globals/recaptcha